### PR TITLE
feat: customize expressiveCode theme styling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,35 @@ export default function starlightThemeBlack(userConfig: StarlightThemeBlackUserC
             starlightConfig.expressiveCode === false
               ? false
               : {
-                  themes: ['github-dark-default', 'github-light-default'],
+                  styleOverrides: {
+                    codeBackground: 'hsl(var(--code-background))',
+                    borderColor: 'hsl(var(--code-background))',
+                    borderRadius: '0.75rem',
+                    textMarkers: {
+                      markBackground: 'hsl(var(--mark-background))',
+                      markBorderColor: 'transparent',
+                      backgroundOpacity: '0.4',
+                      delBorderColor: 'transparent',
+                      insBorderColor: 'transparent',
+                    },
+                    frames: {
+                      editorBackground: 'hsl(var(--code-background))',
+                      editorTabBarBackground: 'hsl(var(--code-background))',
+                      editorTabBarBorderBottomColor: 'hsl(var(--border))',
+                      editorTabBarBorderColor: 'hsl(var(--code-background))',
+                      editorActiveTabBackground: 'hsl(var(--code-background))',
+                      editorActiveTabBorderColor: 'hsl(var(--code-background))',
+                      editorActiveTabIndicatorTopColor: 'hsl(var(--code-background))',
+                      editorActiveTabIndicatorBottomColor: 'hsl(var(--primary))',
+                      tooltipSuccessBackground: 'hsl(var(--input))',
+                      tooltipSuccessForeground: 'hsl(var(--input-foreground))',
+                      frameBoxShadowCssValue: 'unset',
+                      terminalBackground: 'hsl(var(--code-background))',
+                      terminalTitlebarBackground: 'hsl(var(--code-background))',
+                      terminalTitlebarBorderBottomColor: 'hsl(var(--border))',
+                    },
+                  },
+                  themes: ['github-dark-default', 'github-light'],
                   ...(typeof starlightConfig.expressiveCode === 'object' ? starlightConfig.expressiveCode : {}),
                 },
         })

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,6 +5,9 @@
   --radius: 0.5rem;
 
   --sl-color-text-accent: hsl(var(--primary));
+
+  --code-background: 240, 6%, 10%;
+  --mark-background: 240deg 5.26% 26.08% / 50%;
 }
 
 :root[data-theme='dark'] {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE! -->

### Description

This PR customizes the expressiveCode theme configuration inspired by Shadcn. 

### Additional context

The styling approach follows shadcn's design philosophy of clean, accessible, and reusable components while maintaining the theme's identity.

Screenshots:

|Before|After|Shadcn|
|-|-|-|
|![image](https://github.com/user-attachments/assets/cc4719f4-1c10-48d0-b0b3-ae030d5275d7)|![image](https://github.com/user-attachments/assets/96b57d3c-5e74-4bfb-9628-19f13c653d39)|![image](https://github.com/user-attachments/assets/f7b52fde-28e9-47c5-8e3a-8b02765cd2a9)|

Code used in the examples:
```astro
\```astro {2,16}
   ---
   import { Button } from "@/components/ui/button"
   ---

   <html lang="en">
       <head>
           <meta charset="utf-8" />
           <meta name="viewport" content="width=device-width" />
           <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
           <meta name="generator" content={Astro.generator} />
           <title>Astro + TailwindCSS</title>
       </head>

       <body>
           <div class="grid place-items-center h-screen content-center">
               <Button>Button</Button>
           </div>
       </body>
   </html>
\```
```