### PR TITLE
style: adjust the code color of the bright theme

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ export default function starlightThemeBlack(userConfig: StarlightThemeBlackUserC
               : {
                   styleOverrides: {
                     codeBackground: 'hsl(var(--code-background))',
-                    borderColor: 'hsl(var(--code-background))',
+                    borderColor: 'hsl(var(--border))',
                     borderRadius: '0.75rem',
                     textMarkers: {
                       markBackground: 'hsl(var(--mark-background))',
@@ -81,11 +81,11 @@ export default function starlightThemeBlack(userConfig: StarlightThemeBlackUserC
                       editorBackground: 'hsl(var(--code-background))',
                       editorTabBarBackground: 'hsl(var(--code-background))',
                       editorTabBarBorderBottomColor: 'hsl(var(--border))',
-                      editorTabBarBorderColor: 'hsl(var(--code-background))',
+                      editorTabBarBorderColor: 'hsl(var(--border))',
                       editorActiveTabBackground: 'hsl(var(--code-background))',
-                      editorActiveTabBorderColor: 'hsl(var(--code-background))',
+                      editorActiveTabBorderColor: 'hsl(var(--border))',
                       editorActiveTabIndicatorTopColor: 'hsl(var(--code-background))',
-                      editorActiveTabIndicatorBottomColor: 'hsl(var(--primary))',
+                      editorActiveTabIndicatorBottomColor: 'hsl(var(--code-background))',
                       tooltipSuccessBackground: 'hsl(var(--input))',
                       tooltipSuccessForeground: 'hsl(var(--input-foreground))',
                       frameBoxShadowCssValue: 'unset',

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,9 +5,6 @@
   --radius: 0.5rem;
 
   --sl-color-text-accent: hsl(var(--primary));
-
-  --code-background: 240, 6%, 10%;
-  --mark-background: 240deg 5.26% 26.08% / 50%;
 }
 
 :root[data-theme='dark'] {
@@ -30,6 +27,8 @@
   --border: 240 3.7% 15.9%;
   --input: 240 3.7% 15.9%;
   --ring: 240 4.9% 83.9%;
+  --code-background: 240 6% 10%;
+  --mark-background: 240 5.26% 26.08% / 50%;
 }
 
 :root[data-theme='light'] {
@@ -52,6 +51,8 @@
   --border: 240 5.9% 90%;
   --input: 240 5.9% 90%;
   --ring: 240 5% 64.9%;
+  --code-background: 0 0% 100%;
+  --mark-background: 0 0% 100% / 1%;
 }
 
 * {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/adrian-ub/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This pr was born to solve the problem of abnormal color display of code blocks in bright color mode.

### Linked Issues
https://github.com/adrian-ub/starlight-theme-black/issues/5

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Now:

![image](https://github.com/user-attachments/assets/d09ecb4b-2049-4094-943a-f8f3fdd309fb)
![image](https://github.com/user-attachments/assets/fe6c9084-0d68-43c7-80d8-220e3f5519c6)


Before: 
![image](https://github.com/user-attachments/assets/90a7ec3d-a217-44d8-acff-4ac196018928)
![image](https://github.com/user-attachments/assets/dcc82bf7-31f2-4aeb-b88d-b2f6fca6d3bb)
