### PR TITLE
feat: add support for sidebar dropdowns

### DIFF
--- a/packages/starlight-theme-black/libs/config.ts
+++ b/packages/starlight-theme-black/libs/config.ts
@@ -60,6 +60,12 @@ export const StarlightThemeBlackConfigSchema = z.object({
     .default({
       showMarkdownActions: true,
     }),
+
+  sidebar: z
+    .object({
+      useDropdowns: z.boolean().default(false),
+    })
+    .default({ useDropdowns: false }),
 })
 
 export type StarlightThemeBlackUserConfig = z.input<

--- a/packages/starlight-theme-black/overrides/Sidebar.astro
+++ b/packages/starlight-theme-black/overrides/Sidebar.astro
@@ -1,7 +1,10 @@
 ---
 import SidebarSublist from './SidebarSublist.astro'
+import SidebarPersister from '@astrojs/starlight/components/SidebarPersister.astro'
 
 const { sidebar } = Astro.locals.starlightRoute
 ---
 
-<SidebarSublist sublist={sidebar} />
+<SidebarPersister>
+  <SidebarSublist sublist={sidebar} />
+</SidebarPersister>

--- a/packages/starlight-theme-black/overrides/SidebarSublist.astro
+++ b/packages/starlight-theme-black/overrides/SidebarSublist.astro
@@ -119,6 +119,7 @@ const useDropdowns = userConfig.sidebar.useDropdowns
     display: flex;
     flex-direction: column;
     gap: calc(var(--spacing) * 1);
+    min-width: 0;
   }
 
   .container-group-link {

--- a/packages/starlight-theme-black/overrides/SidebarSublist.astro
+++ b/packages/starlight-theme-black/overrides/SidebarSublist.astro
@@ -1,37 +1,70 @@
 ---
 import type { StarlightRouteData } from '@astrojs/starlight/route-data'
+import userConfig from 'virtual:starlight-theme-black-config'
+import { Icon } from '@astrojs/starlight/components'
+import SidebarRestorePoint from '@astrojs/starlight/components/SidebarRestorePoint.astro'
+
+type SidebarEntry = StarlightRouteData['sidebar'][number]
+
+function flattenSidebar(sidebar: SidebarEntry[]): SidebarEntry[] {
+  return sidebar.flatMap((entry) => (entry.type === 'group' ? flattenSidebar(entry.entries) : entry))
+}
 
 interface Props {
   sublist: StarlightRouteData['sidebar']
   nested?: boolean
 }
 
-const { sublist } = Astro.props
+const { sublist, nested } = Astro.props
+const useDropdowns = userConfig.sidebar.useDropdowns
 ---
 
-{
-  sublist.map((entry, index) =>
-    entry.type === 'link' ? (
-      <a
-        href={entry.href}
-        aria-current={entry.isCurrent && 'page'}
-        class:list={['entry-link', entry.attrs.class]}
-        {...entry.attrs}
-      >
-        <span class="entry-link-inner" />
-        {entry.label}
-        {entry.badge && <span class="entry-badge" />}
-      </a>
-    ) : (
-      <div class={`container-sidebar-entry ${index === 0 && !Astro.props.nested ? ' first' : ''}`}>
-        <div class="entry-title">{entry.label}</div>
-        <div class="container-group-link">
-          <Astro.self sublist={entry.entries} nested />
-        </div>
-      </div>
-    ),
-  )
-}
+<ul class:list={{ 'top-level': !nested }}>
+  {
+    sublist.map((entry, index) =>
+      entry.type === 'link' ? (
+        <li>
+          <a
+            href={entry.href}
+            aria-current={entry.isCurrent && 'page'}
+            class:list={['entry-link', entry.attrs.class]}
+            {...entry.attrs}
+          >
+            <span class="entry-link-inner" />
+            {entry.label}
+            {entry.badge && <span class="entry-badge" />}
+          </a>
+        </li>
+      ) : useDropdowns ? (
+        <li>
+          <details
+            open={
+              flattenSidebar(entry.entries).some((i: SidebarEntry) => i.type === 'link' && i.isCurrent) ||
+              !entry.collapsed
+            }
+            class={`container-sidebar-entry ${index === 0 && !nested ? ' first' : ''}`}
+          >
+            <summary class="entry-title">
+              <span>{entry.label}</span>
+              <Icon name="right-caret" class="caret" size="1rem" />
+            </summary>
+            <SidebarRestorePoint />
+            <div class="accordion-content">
+              <Astro.self sublist={entry.entries} nested />
+            </div>
+          </details>
+        </li>
+      ) : (
+        <li class={`container-sidebar-entry ${index === 0 && !nested ? ' first' : ''}`}>
+          <div class="entry-title">{entry.label}</div>
+          <div class="container-group-link">
+            <Astro.self sublist={entry.entries} nested />
+          </div>
+        </li>
+      ),
+    )
+  }
+</ul>
 
 <style>
   .container-sidebar-entry {
@@ -48,6 +81,8 @@ const { sublist } = Astro.props
   }
 
   .entry-title {
+    all: unset;
+    box-sizing: border-box;
     color: var(--muted-foreground);
     font-weight: 500;
     font-size: 0.75rem;
@@ -57,15 +92,39 @@ const { sublist } = Astro.props
     display: flex;
     align-items: center;
     height: calc(var(--spacing) * 8);
+    justify-content: space-between;
+    user-select: none;
+    list-style: none;
+    width: 100%;
+  }
+
+  details > .entry-title {
+    cursor: pointer;
+  }
+
+  .caret {
+    transition: transform 0.2s ease-in-out;
+    flex-shrink: 0;
+  }
+
+  :global([dir='rtl']) .caret {
+    transform: rotateZ(180deg);
+  }
+
+  details[open] > .entry-title > .caret {
+    transform: rotateZ(90deg);
+  }
+
+  .accordion-content {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--spacing) * 1);
   }
 
   .container-group-link {
-    font-size: 0.875rem;
-    line-height: 1.25rem;
-    gap: 2px;
-    grid-auto-rows: max-content;
-    grid-auto-flow: row;
-    display: grid;
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--spacing) * 1);
     width: 100%;
   }
 
@@ -83,8 +142,12 @@ const { sublist } = Astro.props
     display: flex;
     position: relative;
     color: var(--foreground);
+    transition:
+      background-color 0.15s ease,
+      color 0.15s ease;
   }
 
+  .entry-link:hover,
   .entry-link[aria-current='page'] {
     color: var(--sidebar-accent-foreground);
     font-weight: 500;

--- a/packages/starlight-theme-black/styles/base.css
+++ b/packages/starlight-theme-black/styles/base.css
@@ -140,8 +140,8 @@
     padding: 0;
     padding-left: calc(var(--spacing) * 2.5);
     width: calc(var(--spacing) * 56);
-    overflow-x: hidden;
     overflow: auto;
+    overflow-x: hidden;
     min-height: 0;
     gap: calc(var(--spacing) * 2);
     flex-direction: column;
@@ -152,6 +152,7 @@
       list-style: none;
       padding: 0;
       margin: 0;
+      min-width: 0;
       display: flex;
       flex-direction: column;
       gap: calc(var(--spacing) * 1);

--- a/packages/starlight-theme-black/styles/base.css
+++ b/packages/starlight-theme-black/styles/base.css
@@ -148,6 +148,24 @@
     scrollbar-width: none;
     display: flex;
 
+    & ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: calc(var(--spacing) * 1);
+    }
+
+    & li {
+      overflow-wrap: anywhere;
+    }
+
+    & summary::marker,
+    & summary::-webkit-details-marker {
+      display: none;
+    }
+
     --_scroll-fade-size-t: var(--scroll-fade-t-size, var(--scroll-fade-size, min(12%, calc(var(--spacing) * 10))));
     --_scroll-fade-size-b: var(--scroll-fade-b-size, var(--scroll-fade-size, min(12%, calc(var(--spacing) * 10))));
     --scroll-fade-block: linear-gradient(
@@ -357,6 +375,10 @@
   /* global typography refinements */
   * :not(pre) > code {
     border-color: var(--border);
+  }
+
+  html {
+    scrollbar-gutter: stable;
   }
 
   body {


### PR DESCRIPTION
### 🔗 Linked issue

resolves #9 

### 🧭 Context

Starlight has a default feature for their sidebar groups to have a drop-down. This allows for easy organization and hiding of less-important topics. However, when using starlight-theme-black, sidebar groups cannot be collapsed.

### 📚 Description

Add useDropdowns config option to enable collapsible sidebar groups using native `<details>/<summary>` elements, matching Starlight's built-in dropdown behavior.

- Add sidebar.useDropdowns config option (default: false)
- Wrap SidebarSublist with SidebarPersister for state persistence
- Use `<ul>/<li>` structure matching original Starlight component
- Include SidebarRestorePoint for sidebar state restoration
- Add ul/li/reset styles and summary marker hiding in base.css
- Fix overflow-x: hidden order to prevent horizontal scroll
- Add scrollbar-gutter: stable to prevent layout shift

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing!
----------------------------------------------------------------------->
